### PR TITLE
FIXED compareTo bugs about time data

### DIFF
--- a/lib/src/date.dart
+++ b/lib/src/date.dart
@@ -52,6 +52,16 @@ abstract class Date implements Comparable<Date> {
   /// Milliseconds [0..999]
   int get millisecond;
 
+  /// Returns the time part as [Duration].
+  Duration get time {
+    return Duration(
+      hours: hour,
+      minutes: minute,
+      seconds: second,
+      milliseconds: millisecond,
+    );
+  }
+
   /// Julian day number
   ///
   /// subclasses should store this with fast access
@@ -233,11 +243,7 @@ abstract class Date implements Comparable<Date> {
   /// hashcode operator
   @override
   int get hashCode {
-    return julianDayNumber.hashCode ^
-        hour.hashCode ^
-        minute.hashCode ^
-        second.hashCode ^
-        millisecond.hashCode;
+    return julianDayNumber.hashCode ^ time.hashCode;
   }
 
   /// Compare dates
@@ -247,25 +253,14 @@ abstract class Date implements Comparable<Date> {
   int compareTo(Date other) {
     if (identical(this, other)) {
       return 0;
-    } else {
-      if (julianDayNumber == other.julianDayNumber &&
-          hour == other.hour &&
-          minute == other.minute &&
-          second == other.second &&
-          millisecond == other.millisecond) {
-        return 0;
-      } else {
-        if (julianDayNumber >= other.julianDayNumber &&
-            hour >= other.hour &&
-            minute >= other.minute &&
-            second >= other.second &&
-            millisecond >= other.millisecond) {
-          return 1;
-        } else {
-          return -1;
-        }
-      }
     }
+    if (julianDayNumber == other.julianDayNumber) {
+      return time.compareTo(other.time);
+    }
+    if (julianDayNumber > other.julianDayNumber) {
+      return 1;
+    }
+    return -1;
   }
 
   /// bigger than operator

--- a/test/shamsi_date_test.dart
+++ b/test/shamsi_date_test.dart
@@ -548,20 +548,30 @@ void main() {
     final j5 = Jalali(1000, 1, 2, 3, 4, 5, 6);
 
     expect(j5.compareTo(j5) == 0, true);
-    expect(Jalali(1000, 1, 2, 3, 4, 5, 7).compareTo(j5) > 0, true);
+    expect(Jalali(1000, 1, 1, 3, 4, 5, 6).compareTo(j5) < 0, true);
     expect(Jalali(1000, 1, 2, 1, 4, 5, 6).compareTo(j5) < 0, true);
     expect(Jalali(1000, 1, 2, 3, 1, 5, 6).compareTo(j5) < 0, true);
     expect(Jalali(1000, 1, 2, 3, 4, 1, 6).compareTo(j5) < 0, true);
     expect(Jalali(1000, 1, 2, 3, 4, 5, 1).compareTo(j5) < 0, true);
+    expect(Jalali(1000, 1, 3, 2, 4, 5, 6).compareTo(j5) > 0, true);
+    expect(Jalali(1000, 1, 2, 4, 3, 5, 6).compareTo(j5) > 0, true);
+    expect(Jalali(1000, 1, 2, 3, 5, 4, 6).compareTo(j5) > 0, true);
+    expect(Jalali(1000, 1, 2, 3, 4, 6, 5).compareTo(j5) > 0, true);
+    expect(Jalali(1000, 1, 2, 3, 4, 5, 7).compareTo(j5) > 0, true);
 
     expect(j5 == j5, true);
     expect(j5 >= j5, true);
     expect(j5 <= j5, true);
-    expect(Jalali(1000, 1, 2, 3, 4, 5, 7) > j5, true);
+    expect(Jalali(1000, 1, 1, 3, 4, 5, 6) < j5, true);
     expect(Jalali(1000, 1, 2, 1, 4, 5, 6) < j5, true);
     expect(Jalali(1000, 1, 2, 3, 1, 5, 6) < j5, true);
     expect(Jalali(1000, 1, 2, 3, 4, 1, 6) < j5, true);
     expect(Jalali(1000, 1, 2, 3, 4, 5, 1) < j5, true);
+    expect(Jalali(1000, 1, 3, 2, 4, 5, 6) > j5, true);
+    expect(Jalali(1000, 1, 2, 4, 3, 5, 6) > j5, true);
+    expect(Jalali(1000, 1, 2, 3, 5, 4, 6) > j5, true);
+    expect(Jalali(1000, 1, 2, 3, 4, 6, 5) > j5, true);
+    expect(Jalali(1000, 1, 2, 3, 4, 5, 7) > j5, true);
   });
 
   test('Gregorian.{ compareTo , > , >= , == ,  <= , < }', () {
@@ -593,20 +603,30 @@ void main() {
     final g5 = Gregorian(1000, 1, 2, 3, 4, 5, 6);
 
     expect(g5.compareTo(g5) == 0, true);
-    expect(Gregorian(1000, 1, 2, 3, 4, 5, 7).compareTo(g5) > 0, true);
+    expect(Gregorian(1000, 1, 1, 3, 4, 5, 6).compareTo(g5) < 0, true);
     expect(Gregorian(1000, 1, 2, 1, 4, 5, 6).compareTo(g5) < 0, true);
     expect(Gregorian(1000, 1, 2, 3, 1, 5, 6).compareTo(g5) < 0, true);
     expect(Gregorian(1000, 1, 2, 3, 4, 1, 6).compareTo(g5) < 0, true);
     expect(Gregorian(1000, 1, 2, 3, 4, 5, 1).compareTo(g5) < 0, true);
+    expect(Gregorian(1000, 1, 3, 2, 4, 5, 6).compareTo(g5) > 0, true);
+    expect(Gregorian(1000, 1, 2, 4, 3, 5, 6).compareTo(g5) > 0, true);
+    expect(Gregorian(1000, 1, 2, 3, 5, 4, 6).compareTo(g5) > 0, true);
+    expect(Gregorian(1000, 1, 2, 3, 4, 6, 5).compareTo(g5) > 0, true);
+    expect(Gregorian(1000, 1, 2, 3, 4, 5, 7).compareTo(g5) > 0, true);
 
     expect(g5 == g5, true);
     expect(g5 >= g5, true);
     expect(g5 <= g5, true);
-    expect(Gregorian(1000, 1, 2, 3, 4, 5, 7) > g5, true);
+    expect(Gregorian(1000, 1, 1, 3, 4, 5, 6) < g5, true);
     expect(Gregorian(1000, 1, 2, 1, 4, 5, 6) < g5, true);
     expect(Gregorian(1000, 1, 2, 3, 1, 5, 6) < g5, true);
     expect(Gregorian(1000, 1, 2, 3, 4, 1, 6) < g5, true);
     expect(Gregorian(1000, 1, 2, 3, 4, 5, 1) < g5, true);
+    expect(Gregorian(1000, 1, 3, 2, 4, 5, 6) > g5, true);
+    expect(Gregorian(1000, 1, 2, 4, 3, 5, 6) > g5, true);
+    expect(Gregorian(1000, 1, 2, 3, 5, 4, 6) > g5, true);
+    expect(Gregorian(1000, 1, 2, 3, 4, 6, 5) > g5, true);
+    expect(Gregorian(1000, 1, 2, 3, 4, 5, 7) > g5, true);
   });
 
   test('JalaliFormatter(date).{date}', () {


### PR DESCRIPTION
The `compareTo` method returns +1 only if **all** parts (ANDs) of `this` date are greater than or equal `other` date.
Consider the following two different times: 
1. 1400/01/01 10:10:10.999
2. 1400/01/01 11:09:10.999

The second one is greater than the first because of its hour but its minute is less than the first.
I fixed the bug and added the relevant tests.