### PR TITLE
feat: factory function 'fromMilliseconds' added

### DIFF
--- a/lib/src/gregorian/gregorian_date.dart
+++ b/lib/src/gregorian/gregorian_date.dart
@@ -162,6 +162,12 @@ class Gregorian extends Date {
     );
   }
 
+  /// Create a Gregorian date from milliseconds since epoch
+  factory Gregorian.fromMillisecondsSinceEpoch(int milliseconds) {
+    return Gregorian.fromDateTime(
+        DateTime.fromMillisecondsSinceEpoch(milliseconds));
+  }
+
   /// Get Gregorian date for now
   factory Gregorian.now() {
     return Gregorian.fromDateTime(DateTime.now());

--- a/lib/src/jalali/jalali_date.dart
+++ b/lib/src/jalali/jalali_date.dart
@@ -167,6 +167,12 @@ class Jalali extends Date {
     );
   }
 
+  /// Create a Jalali date from milliseconds since epoch
+  factory Jalali.fromMillisecondsSinceEpoch(int milliseconds) {
+    return Jalali.fromDateTime(
+        DateTime.fromMillisecondsSinceEpoch(milliseconds));
+  }
+
   /// Get Jalali date for now
   factory Jalali.now() {
     return Gregorian.now().toJalali();

--- a/test/shamsi_date_test.dart
+++ b/test/shamsi_date_test.dart
@@ -2449,6 +2449,26 @@ void main() {
     expect(Gregorian(2119, 3, 21), Jalali(1498));
     expect(true, Jalali(1498).isLeapYear());
   });
+
+  test('Gregorian FromMilliseconds Test Cases', () {
+    const millis = 1722319497219;
+    var gdt = Gregorian.fromMillisecondsSinceEpoch(millis);
+    expect(gdt.year, 2024);
+    expect(gdt.month, 7);
+    expect(gdt.day, 30);
+    expect(gdt.hour, 9);
+    expect(gdt.minute, 34);
+  });
+
+  test('Jalali FromMilliseconds Test Cases', () {
+    const millis = 1722319497219;
+    var jdt = Jalali.fromMillisecondsSinceEpoch(millis);
+    expect(jdt.year, 1403);
+    expect(jdt.month, 5);
+    expect(jdt.day, 9);
+    expect(jdt.hour, 9);
+    expect(jdt.minute, 34);
+  });
 }
 
 /// Mock Gregorian

--- a/test/shamsi_date_test.dart
+++ b/test/shamsi_date_test.dart
@@ -2452,22 +2452,30 @@ void main() {
 
   test('Gregorian FromMilliseconds Test Cases', () {
     const millis = 1722319497219;
-    var gdt = Gregorian.fromMillisecondsSinceEpoch(millis);
+    final timezone = DateTime.now().timeZoneOffset;
+    final gdt = Gregorian.fromMillisecondsSinceEpoch(
+        millis - timezone.inMilliseconds); // defusing timezone
     expect(gdt.year, 2024);
     expect(gdt.month, 7);
     expect(gdt.day, 30);
-    expect(gdt.hour, 9);
-    expect(gdt.minute, 34);
+    expect(gdt.hour, 6);
+    expect(gdt.minute, 4);
+    expect(gdt.second, 57);
+    expect(gdt.millisecond, 219);
   });
 
   test('Jalali FromMilliseconds Test Cases', () {
     const millis = 1722319497219;
-    var jdt = Jalali.fromMillisecondsSinceEpoch(millis);
+    final timezone = DateTime.now().timeZoneOffset;
+    final jdt = Jalali.fromMillisecondsSinceEpoch(
+        millis - timezone.inMilliseconds); // defusing timezone
     expect(jdt.year, 1403);
     expect(jdt.month, 5);
     expect(jdt.day, 9);
-    expect(jdt.hour, 9);
-    expect(jdt.minute, 34);
+    expect(jdt.hour, 6);
+    expect(jdt.minute, 4);
+    expect(jdt.second, 57);
+    expect(jdt.millisecond, 219);
   });
 }
 


### PR DESCRIPTION
Hello.

By merging this PR users can write shorter code.

Before:
```dart
var jdt = Jalali.fromDateTime(DateTime.fromMillisecondsSinceEpoch(milliseconds));
```

After:
```dart
var jdt = Jalali.fromMillisecondsSinceEpoch(milliseconds); 
```

This factory function added to 'Gregorian' class too.

Tests are included in this PR.